### PR TITLE
addition of bn_out_hex function.

### DIFF
--- a/sql/bignum.sql
+++ b/sql/bignum.sql
@@ -40,6 +40,10 @@ RETURNS CSTRING
 AS 'bignum', 'pgx_bignum_out'
 LANGUAGE C IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION bn_out_hex(bignum)
+RETURNS CSTRING AS 'bignum', 'pgx_bignum_out_hex'
+LANGUAGE C IMMUTABLE STRICT;
+
 CREATE OR REPLACE FUNCTION bn_in(cstring)
 RETURNS bignum
 AS 'bignum', 'pgx_bignum_in_asc'

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -19,6 +19,7 @@ Datum pgx_bignum_in_asc(PG_FUNCTION_ARGS);
 Datum pgx_bignum_in_hex(PG_FUNCTION_ARGS);
 Datum pgx_bignum_in_dec(PG_FUNCTION_ARGS);
 Datum pgx_bignum_out(PG_FUNCTION_ARGS);
+Datum pgx_bignum_out_hex(PG_FUNCTION_ARGS);
 
 Datum BnGetDatum(BIGNUM *bn);
 


### PR DESCRIPTION
Hi, Evan!

Thank you so much for the good extension.
I want to offer some additional function for output bignum value in hex.

```
t=# create table t(a bignum, b bignum);
CREATE TABLE
t=# insert into t values(bn_in_hex('ffffffffffffffff'),bn_in_hex('ffffffffffffffff'));
INSERT 0 1
t=# select bn_out_hex((a+1) * (b+1)) from t;
             bn_out_hex
------------------------------------
 0100000000000000000000000000000000
(1 row)
```

In awaiting for your feedback,
Sincerely,
dbdeadka